### PR TITLE
Enable non-root users to run the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine
 
 RUN apk --update --no-cache add apache2 && \
-mkdir -p /run/apache2 && mkdir -p /web && chown -R apache:apache /web && \
+mkdir -p /run/apache2 && chmod 775 /run/apache2 && mkdir -p /web && chown -R apache:apache /web && \
+sed -i 's/Listen 80/Listen 8080/' /etc/apache2/httpd.conf && \
 sed -i 's#^DocumentRoot ".*#DocumentRoot "/web"#g' /etc/apache2/httpd.conf && \
 sed -i 's#^<Directory ".*htdocs.*#<Directory "/web">#' /etc/apache2/httpd.conf && \
 sed -i 's/AllowOverride [Nn]one/AllowOverride All/' /etc/apache2/httpd.conf && \
@@ -10,6 +11,9 @@ sed -i 's#logs/.*\.log#/dev/stdout#g' /etc/apache2/httpd.conf && \
 echo 'Alias "${WEB_PATH}" /web' >> /etc/apache2/httpd.conf && \
 echo "Success."
 
-EXPOSE 80
+ADD apache2-foreground.sh /apache2-foreground.sh
+RUN chmod 755 /apache2-foreground.sh
+
+EXPOSE 8080
 WORKDIR /web
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ sed -i 's#logs/.*\.log#/dev/stdout#g' /etc/apache2/httpd.conf && \
 echo 'Alias "${WEB_PATH}" /web' >> /etc/apache2/httpd.conf && \
 echo "Success."
 
-ADD apache2-foreground.sh /apache2-foreground.sh
-RUN chmod 755 /apache2-foreground.sh
-
 EXPOSE 8080
 WORKDIR /web
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,21 @@ Super basic Apache2 image based on Alpine.
 Either copy or volume your content into `/web` when running - e.g.
 
 ```
-docker run --volume ${PWD}:/web --publish 80:80 caseyfw/apache
+docker run --volume ${PWD}:/web --publish 80:8080 caseyfw/apache
 ```
 
 The `$WEB_PATH` environment variable can be used to set the sub-path your
 web root is served from. This should start with a slash - e.g. `/foo/bar`.
 
 ```
-docker run -v ${PWD}:/web -p 80:80 -e "WEB_PATH=/foo/bar" caseyfw/apache
+docker run -v ${PWD}:/web -p 80:8080 -e "WEB_PATH=/foo/bar" caseyfw/apache
 ```
 
 This will result in your content being served at http://localhost/foo/bar/.
+
+Note that this image uses port 8080 by default, allowing it to be run by a
+non-root user.
+
+```
+docker run -v ${PWD}:/web -p 80:8080 -u 1000 caseyfw/apache
+```


### PR DESCRIPTION
This makes it easier to use this image with orchestration platforms that value security like Kubernetes, OpenShift, etc.